### PR TITLE
save to source file for Dropbox

### DIFF
--- a/src/composables/useFlogs.ts
+++ b/src/composables/useFlogs.ts
@@ -1,5 +1,14 @@
 import { ref } from "vue"
 import { IFlog } from "@/modules/Flog"
+import { IEntry } from '@/modules/EntryData'
+import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
+// import { useLocalFileFlogs } from "@/composables/useLocalFileFlogs";
+
+const {
+    saveFlogEntries,
+} = useDropboxFlogs();
+
+//   const { selectedFileFlog, launchOpenFileFlow, launchRequestPermissionsFlow } = useLocalFileFlogs();
 
 // Using module-scoped state can cause problems with SSR. See 
 // https://vuejs.org/guide/scaling-up/state-management#simple-state-management-with-reactivity-api
@@ -22,9 +31,35 @@ export const useFlogs = () => {
         }
     }
 
+    const addEntryToFlog = (entry: IEntry, flog: IFlog) => {
+        const sourceType = flog.url.split(':')[0];
+        switch (sourceType) {
+            case 'local file':
+                break;
+            case 'dropbox':
+                break;
+            default:
+        }
+    }
+
+    const saveFlogToSource = (flog: IFlog) => {
+        const sourceType = flog.url.split(':')[0];
+        console.log('saveFlogToSource, sourceType = ', sourceType)
+        switch (sourceType) {
+            case 'local file':
+                break;
+            case 'dropbox':
+                saveFlogEntries(flog)
+                break;
+            default:
+        }
+    }
+
     return {
         openFlogs,
         openFlog,
-        closeFlog
+        closeFlog,
+        addEntryToFlog,
+        saveFlogToSource
     }
 }


### PR DESCRIPTION
Added useFlogs.saveFlogToSource, which implements saveFlogEntries for each source type.
Along with useDropboxFlogs.saveFlogEntries and useDropboxFiles.saveFileContent, which uses dbx.filesUpload.