### PR TITLE
Add first-class property for Flog.sourceType, rather than prefixing the url property.

### DIFF
--- a/src/composables/useDropboxFlogs.ts
+++ b/src/composables/useDropboxFlogs.ts
@@ -33,14 +33,6 @@ const {
     addFile
 } = useDropboxFiles()
 
-const filePathToFlogUrl = (path: string): string => {
-    return 'dropbox: ' + path
-}
-
-const flogUrlToFilePath = (url: string): string => {
-    return url.replace(/^dropbox: /, '')
-}
-
 export const useDropboxFlogs = (): IDropboxFlogs => {
 
     const availableFlogs = ref([]);
@@ -50,10 +42,10 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
         (availableFiles, oldValue) => {
             const removed = !oldValue ? [] : oldValue
                 .filter((file) => availableFiles && !availableFiles.includes(file))
-                .map<IDropboxFlog>((file) => ({ url: filePathToFlogUrl(file.path) } as IDropboxFlog))
+                .map<IDropboxFlog>((file) => ({ sourceType: 'dropbox', url: file.path } as IDropboxFlog))
             const added = !availableFiles ? [] : availableFiles
                 .filter((file) => oldValue && !oldValue.includes(file))
-                .map<IDropboxFlog>((file) => ({ url: filePathToFlogUrl(file.path) } as IDropboxFlog))
+                .map<IDropboxFlog>((file) => ({ sourceType: 'dropbox', url: file.path } as IDropboxFlog))
             availableFlogs.value = availableFlogs.value
                 .filter((flog) => !removed.includes(flog))
                 .concat(added)
@@ -64,7 +56,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
     const loadFlogEntries = (flog: IDropboxFlog) => {
         console.log('loadFlogEntries flog', flog)
         loadFileContent(
-            { path: flogUrlToFilePath(flog.url) },
+            { path: flog.url },
             (result) => {
                 flog.loadedEntries = deserializeEntries(result.content)
                 flog.rev = result.rev;
@@ -76,7 +68,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
         console.log('saveFlogEntries flog', flog)
         saveFileContent(
             {
-                path: flogUrlToFilePath(flog.url),
+                path: flog.url,
                 // rev is required, but I'm not 100% sure of usage. 
                 // Might be required like this to ensure writing new version of current version. 
                 // Or, it might allow specing a new rev to version rather than overwrite.
@@ -91,7 +83,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
         console.log('addFlog flog', flog)
         addFile(
             {
-                path: flogUrlToFilePath(flog.url),
+                path: flog.url,
                 // Is rev needed for mode add?
                 // rev: flog.rev, 
                 content: serializeEntries(flog.loadedEntries)

--- a/src/composables/useFlogs.ts
+++ b/src/composables/useFlogs.ts
@@ -60,8 +60,7 @@ export const useFlogs = () => {
     };
 
     const saveFlogToSource = (flog: IFlog) => {
-        const sourceType = flog.url.split(':')[0];
-        switch (sourceType) {
+        switch (flog.sourceType) {
             case 'local file':
                 saveFlogEntries_localFiles(flog as IFileFlog)
                 break;
@@ -73,8 +72,7 @@ export const useFlogs = () => {
     }
 
     const addFlogToSource = (flog: IFlog) => {
-        const sourceType = flog.url.split(':')[0];
-        switch (sourceType) {
+        switch (flog.sourceType) {
             case 'local file':
                 addFlog_localFiles(flog as IFileFlog)
                 break;

--- a/src/composables/useLocalFileFlogs.ts
+++ b/src/composables/useLocalFileFlogs.ts
@@ -194,7 +194,8 @@ export const useLocalFileFlogs = (dataLoadedCallback): IFileFlogs => {
             dataFileDataStr.value = await dataFile.text();
             // parse file contents
             selectedFileFlog.value = {
-                url: 'Local file: ' + dataFileName.value,
+                sourceType: 'local file',
+                url: dataFileName.value,
                 permissions: dataFilePermissions.value,
                 loadedEntries: deserializeEntries(dataFileDataStr.value),
             }

--- a/src/modules/Flog.ts
+++ b/src/modules/Flog.ts
@@ -1,20 +1,18 @@
 import { IEntry } from './EntryData'
 
 export interface IFlog {
+    sourceType: "dropbox" | "local file",
     url: string,
     permissions?: string,
     loadedEntries: IEntry[],
 }
 
 export function serializeEntries(entriesList: IEntry[]): string {
-    console.log('entriesList', entriesList)
     return entriesList.reduce<string>(
         (accumulatedValue, currentEntry, index) => {
-            console.log(currentEntry)
             const entryString = `${currentEntry.date.toLocaleDateString()}`
                 + "\n"
                 + `${currentEntry.entry}`
-            console.log(currentEntry, entryString)
             return accumulatedValue + ((index > 0) ? '\n\n' : '') + entryString
         }
         , '' //start accumulatedValue with an empty string


### PR DESCRIPTION
As pointed out by @alvarix , on 10/11:
```
const sourceType = flog.url.split(':')[0];
```
I found this a bit frustrating because it means we can add any HTML to the display title.
It may become a moot point since we only haave one source to display, but seems like it'd be go in general to have seperate properties for slug (logic) and display.
