### PR TITLE
Alvar/resize textarea and UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,6 +58,11 @@ const { clearConnection } = useDropboxFlogs();
   </template>
 
  <style scoped lang="stylus">
+ 
+#logo
+    margin-bottom 0
+    padding-bottom 0
+
  .header 
     display flex
     flex-direction row-reverse

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,20 +18,23 @@ const { clearConnection } = useDropboxFlogs();
 </script>
 
 <template>
-  <div :class="{ 'connected' : hasConnection }">
-    <ThemeSwitcher />
-    
-    <div
-      id="authed-section"
-      :style="{ display: hasConnection ? 'block' : 'none' }"
-    >
-      <button class="dbx__btn small" @click="clearConnection">
-        <img alt="Dropbox account" src="/Dropbox_Icon.svg" width="16" height="16"> Disconnect {{ accountOwner }}
-      </button>
-    </div>
-    
+  <main :class="{ 'connected' : hasConnection }">
+    <div class="header">
 
-    <div>
+      <div class="theme-controls">
+        <ThemeSwitcher />
+        
+        <div
+          id="authed-section"
+          :style="{ display: hasConnection ? 'block' : 'none' }"
+        >
+          <button class="dbx__btn small" @click="clearConnection">
+            <img alt="Dropbox account" src="/Dropbox_Icon.svg" width="16" height="16"> Disconnect {{ accountOwner }}
+          </button>
+        </div>
+      </div>
+      
+
       <h1 id="logo">
         <pre>
 ███████╗██╗      ██████╗  ██████╗  ██████╗ ███████╗██████╗ 
@@ -51,15 +54,18 @@ const { clearConnection } = useDropboxFlogs();
     <OpenFlogs />
     <br />
     <EntryList :entries="loadedEntries || []" />
-  </div>
+  </main>
   </template>
 
  <style scoped lang="stylus">
+ .header 
+    display flex
+    flex-direction row-reverse
+    justify-content space-between
+    @media (max-width: 499px)
+        flex-direction column
+    
   .dbx__btn
-    position absolute
-    top 55px
-    right 20px
-    margin-top 0
     display flex
     align-items center
     gap 5px

--- a/src/DbAuthPopup.vue
+++ b/src/DbAuthPopup.vue
@@ -24,6 +24,6 @@ import PacmanLoader from 'vue-spinner/src/PacmanLoader.vue'
 }
 
 * {
-    font-family Inter, system-ui, Avenir, Helvetica, Arial, sans-serif
+    font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif
 }
 </style>

--- a/src/DbAuthPopup.vue
+++ b/src/DbAuthPopup.vue
@@ -24,7 +24,6 @@ import PacmanLoader from 'vue-spinner/src/PacmanLoader.vue'
 }
 
 * {
-  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
-    "DejaVu Sans Mono", monospace;
+    font-family Inter, system-ui, Avenir, Helvetica, Arial, sans-serif
 }
 </style>

--- a/src/components/AddEntry.vue
+++ b/src/components/AddEntry.vue
@@ -80,7 +80,7 @@ watch(() => props.copiedEntry, (newVal) => {
 	</form>
 </template>
 
-<style scoped>
+<style lang='styl' scoped>
 #add-entry *:not(.date-validation) {
 	display:block;
 }
@@ -89,15 +89,12 @@ input.error {
 	border:1px solid var(--red-color);
 }
 
-input[type='submit'],
-.form-inner,
-.form-inner * {
-	background-color:var(--input-color);
-}
 
+.form-inner .date	
+	background none
+	margin-left 10px
 
-
-.form-inner {
+.form-inner textarea{
     max-width: 600px;
     border-radius: 14px;
     padding: 20px;

--- a/src/components/AddEntry.vue
+++ b/src/components/AddEntry.vue
@@ -72,7 +72,7 @@ watch(() => props.copiedEntry, (newVal) => {
 				<em class='date-validation hidden' :class={error:hasError}>Please enter valid date</em>
 			</div>
 			<div>
-				<textarea class='auto-resize' autofocus id="entry" name="" cols="30" rows="2" v-model='form.entry' required></textarea>
+				<textarea class='auto-resize' autofocus id="entry" name=""  v-model='form.entry' required></textarea>
 			</div>
 		</div>
 		<div><button class="big" type="submit">Add Entry</button></div>
@@ -89,7 +89,6 @@ input.error {
 	border:1px solid var(--red-color);
 }
 
-
 .form-inner .date	
 	background none
 	margin-left 10px
@@ -99,7 +98,6 @@ input.error {
     border-radius: 14px;
     padding: 20px;
 }
-
 
 input.date {
 	font-weight: bold;
@@ -113,6 +111,7 @@ input, textarea {
 
 textarea {
 	width: 100%;
+	box-sizing border-box
 }
 
 .date-validation.error {

--- a/src/components/AddEntry.vue
+++ b/src/components/AddEntry.vue
@@ -42,7 +42,7 @@ const autoResizeTextarea = (el_id) => {
   }
 };
 
-
+// this watch is triggered when copying an entry
 watch(() => props.copiedEntry, (newVal) => {
   if (newVal && newVal.entry) {
     form.value.entry = newVal.entry; // Prepopulate the textarea with the copied entry

--- a/src/components/AddFlog.vue
+++ b/src/components/AddFlog.vue
@@ -76,7 +76,6 @@ const handleKeydown = (e) => {
     </button>
   </div>
   <form v-else id="add-flog" @submit.prevent="submitAdd" @mouseleave="hideDropdown" @keydown="handleKeydown">
-    <div class="form-inner">
       <div class="filename-controls">
         <input
           autofocus
@@ -104,7 +103,6 @@ const handleKeydown = (e) => {
           >Please enter valid file name</em
         >
       </div>
-    </div>
 <!--
     <div>
       <input

--- a/src/components/AddFlog.vue
+++ b/src/components/AddFlog.vue
@@ -103,19 +103,6 @@ const handleKeydown = (e) => {
           >Please enter valid file name</em
         >
       </div>
-<!--
-    <div>
-      <input
-        type="button"
-        value="Cancel"
-        @click="
-          () => {
-            showInput = false;
-          }
-        "
-      />
-    </div>
-  -->
   </form>
 </template>
 
@@ -148,13 +135,9 @@ input[type="button"] {
   cursor: pointer;
 }
 
-  
-  
 .filename-controls 
     position: relative;
   
-
-
 .filename 
   background-color: var(--input-color);
   padding 20px
@@ -162,7 +145,7 @@ input[type="button"] {
   font-weight: bold;
   border-color: lightsteelblue 
   border-style solid
-  font-size: 14px;
+  font-size: 16px;
   outline-color: var(--input-color)
   width: 100%;
   box-sizing: border-box;

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -73,9 +73,8 @@ function save(entry) {
 h3 {
   font-weight: 700;
   font-size: 14px;
-  margin: 40px 0 0 20px;
+  margin: 50px 0 20px 20px;
 }
-
 
 .entry__body {
   background-color: var(--misc-color);
@@ -84,6 +83,11 @@ h3 {
 .entry__pre
   white-space: pre-wrap;
 
+.entry__body,
+.entry__textarea {
+  font-size: 14px;
+}
+
 .entry__body, 
 .entry textarea,
 .entry input {
@@ -91,9 +95,7 @@ h3 {
   max-width: 600px;
   border-radius: 14px;
   padding: 20px;
-  font-size: 12px;
   padding: 10px 20px ;
-  
 }
 
 .entry__textarea {
@@ -104,6 +106,9 @@ h3 {
 .entry__body:hover {
   background-color: var(--input-color);
 }
+
+
+
 
 
 

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -36,10 +36,13 @@ function edit(entry) {
   nextTick(() => {
     if (entryTextarea.value) {
       entryTextarea.value.focus({ preventScroll: true });
-      // Set cursor position to the start of the text
+      // auto resize
       entryTextarea.value.style.height = entryTextarea.value.scrollHeight + "px";
+      // Set cursor position to the start of the text
       entryTextarea.value.selectionStart = 0;
       entryTextarea.value.selectionEnd = 0;
+      // scroll to 
+      entryTextarea.value.scrollIntoView({ behavior: "smooth" });
     }
   });
 }

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -85,7 +85,8 @@ h3 {
 
 .entry__body,
 .entry__textarea {
-  font-size: 14px;
+  font-size: 16px;
+  font-family: var(--font);
   width 100%
   box-sizing border-box
 }

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -86,6 +86,8 @@ h3 {
 .entry__body,
 .entry__textarea {
   font-size: 14px;
+  width 100%
+  box-sizing border-box
 }
 
 .entry__body, 

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -37,6 +37,7 @@ function edit(entry) {
     if (entryTextarea.value) {
       entryTextarea.value.focus({ preventScroll: true });
       // Set cursor position to the start of the text
+      entryTextarea.value.style.height = entryTextarea.value.scrollHeight + "px";
       entryTextarea.value.selectionStart = 0;
       entryTextarea.value.selectionEnd = 0;
     }
@@ -88,13 +89,13 @@ h3 {
   border-radius: 14px;
   padding: 20px;
   font-size: 12px;
-  height: auto;
   padding: 10px 20px ;
   
 }
 
 .entry__textarea {
   background-color: var(--input-color);
+  max-width: 95%;
 }
 
 .entry__body:hover {

--- a/src/components/OpenFlogs.vue
+++ b/src/components/OpenFlogs.vue
@@ -23,6 +23,7 @@ function addNewEntry(entryData, flog) {
   );
   addEntryToFlog(newEntry, flog);
   saveFlogToSource(flog);
+  alert("New entry added");
 }
 const copiedEntry = ref(null); // Initialize reactive copiedEntry
 let isEditing = ref(false);

--- a/src/components/OpenFlogs.vue
+++ b/src/components/OpenFlogs.vue
@@ -68,22 +68,21 @@ const getTimestamp = () => ref(new Date().toLocaleDateString());
       <h4 class="flog-title">
         {{ flog.url }}
 
+        <span v-if="flog.pretext?.trim() != ''">
+          <Pretext :pretext="flog.pretext"/>
+        </span>
         <button class="small close-flog" @click.prevent="() => closeFlog(flog)">
           close flog
         </button>
       </h4>
-      <div v-if="flog.pretext?.trim() != ''">
-        <h5 class="no-margin-bottom">pretext</h5>
-        <Pretext :pretext="flog.pretext"/>
-      </div>
-      <div v-else>
-        <h5>no pretext</h5>
-      </div>
+      
       <AddEntry
-        @newEntry="(entryData) => addNewEntry(entryData, flog)"
-        :copiedEntry="copiedEntry"
-        :timestamp="getTimestamp()"
+      @newEntry="(entryData) => addNewEntry(entryData, flog)"
+      :copiedEntry="copiedEntry"
+      :timestamp="getTimestamp()"
       />
+      
+
       <EntryList
         :entries="flog.loadedEntries"
         :isEditing="isEditing"
@@ -98,10 +97,11 @@ const getTimestamp = () => ref(new Date().toLocaleDateString());
 </template>
 
 <style scoped lang="styl">
-h4 {
-  padding: 0;
-  margin-bottom: 0px;
-}
+h4 
+  margin 10px 0 10px
+  padding 0 0 10px 0
+  font-style italic 
+
 .no-margin-bottom {
   margin-bottom: 0px;
 }
@@ -109,6 +109,6 @@ h5 {
   padding: 0;
 }
 
-button.close-flog 
+button.small
   margin-left 10px
 </style>

--- a/src/components/OpenFlogs.vue
+++ b/src/components/OpenFlogs.vue
@@ -97,7 +97,7 @@ const getTimestamp = () => ref(new Date().toLocaleDateString());
   </section>
 </template>
 
-<style scoped>
+<style scoped lang="styl">
 h4 {
   padding: 0;
   margin-bottom: 0px;
@@ -109,4 +109,6 @@ h5 {
   padding: 0;
 }
 
+button.close-flog 
+  margin-left 10px
 </style>

--- a/src/components/Pretext.vue
+++ b/src/components/Pretext.vue
@@ -7,22 +7,24 @@ const props = defineProps<{
 </script>
 
 <template>
-  <form @submit.prevent="">
-    <div class="form-inner">
-      <div>
-        <textarea
-          autofocus
-          id="pretext"
-          v-model="props.pretext"
-          disabled
-          class="auto-resize"
-        ></textarea>
-      </div>
-    </div>
-  </form>
+  <button class='small popbutton' popovertarget="my-popover">Flog Info</button>
+  <div v-text="props.pretext" id="my-popover" popover class="popover"> </div>
 </template>
 
-<style>
+<style lang="styl" scoped>
+
+
+.popover 
+  font-weight: 400;
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  max-width: 20ch;
+  line-height: 1.4;
+  border:0
+  top: 2rem;
+  margin: 0 auto;
+  box-shadow 0 0 6px #999
+
 form {
   padding: 0px 0px 10px 0px;
   margin: 0px 0px 42px 0px;

--- a/src/components/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher.vue
@@ -1,6 +1,5 @@
 // ThemeSwitcher.vue
 <template>
-  <div class="theme-controls">
     <button class="small" @click="toggleTheme">
       {{ isDark ? '🌙 Dark' : '☀️ Light' }}
     </button>
@@ -11,7 +10,6 @@
      (Following System) 
       
     </span>
-  </div>
 </template>
 
 <script setup lang="ts">
@@ -25,9 +23,6 @@ const { isDark, isSystemTheme, toggleTheme, resetToSystem } = useTheme()
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  position absolute
-  top 15px
-  right 20px
   margin-top 0
 }
 

--- a/src/globalcss.styl
+++ b/src/globalcss.styl
@@ -1,5 +1,6 @@
 :root 
     font-family Inter, system-ui, Avenir, Helvetica, Arial, sans-serif
+    font-size 16px
     line-height 1.5
     font-weight 400
     color-scheme light dark
@@ -28,7 +29,8 @@
     --red-color light-dark(#e0521d, #e0521d)
 
 li a
-  word-break: break-all;
+  word-break break-all
+  overflow-wrap break-word
 
 button 
     background-color var(--button-color)
@@ -66,7 +68,7 @@ input:not(submit), textarea
 body 
     background-color var(--bg-color)
     color var(--color)
-    font-family ui-monospace "Cascadia Code" "Source Code Pro" Menlo Consolas
+    Xfont-family ui-monospace "Cascadia Code" "Source Code Pro" Menlo Consolas
 
 a
     font-weight 500
@@ -110,7 +112,7 @@ h1
 
 h2
   font-size 2em
-  font-family "DejaVu Sans Mono", monospace
+  Xfont-family "DejaVu Sans Mono", monospace
 
 h3
     font-size 1.3em
@@ -120,6 +122,7 @@ h4
     font-weight 600
 
 #app
+    box-sizing border-box
     max-width 1280px
     margin 0 auto
     padding 2rem
@@ -139,6 +142,8 @@ ul
 
 .auto-resize 
     field-sizing content
+
+
 
 
 //@media (max-width: 499px)

--- a/src/globalcss.styl
+++ b/src/globalcss.styl
@@ -17,6 +17,7 @@
     --accent-bold #646cff
     */
 
+    --font Inter, system-ui, Avenir, Helvetica, Arial, sans-serif
     --misc-color light-dark(#ebe8dc, #252521)
     --button-color light-dark(#eae8df, #252521)
     

--- a/src/globalcss.styl
+++ b/src/globalcss.styl
@@ -61,8 +61,6 @@ input:not(submit), textarea
 
 #logo pre 
     color var(--color)
-    @media (max-width: 450px)
-        margin-top 30px
 
     
 body 
@@ -141,3 +139,6 @@ ul
 
 .auto-resize 
     field-sizing content
+
+
+//@media (max-width: 499px)


### PR DESCRIPTION
UI changes to push to beta.
@chadcrume below is my current punch list. 
Im pushing up early because I wanted to show you a refactor of pretext. 
For one Im using the new CSS popover element. 

Two, I opted to refactor the use of HTML elements to match the pattern I started where form elements are only used in editable areas (the exception is the date in add entry, but styled to look like it's ineditable).
So if the flog info is made editable, it will conditionally show the content in a textarea (tbd, see edit entry). 

There is an argument to be made to the contrary, ie. that we should only use form elements and just style them differently depending on if they're editable or not. But this is the pattern I took, so we should follow it unless we decide not to. 
Let's discuss.

[Vercel Preview](https://flogger-m7opffgjc-alvarixs-projects.vercel.app/)


- Mobile
	- auto-resize textarea
		1. [x] Edit (also gets too long)
		2. [x] Copy
	- edit
		1. [x] scroll to
		2. [x] fz
	- add
		1. [ ] feedback
		2. [x] style like entry
	- omnibox
		1. [x] style
		2. [ ] width
	- [x] disconnect button logo overlap
- Pretext 
	1. [x] change 'pretext' to 'Log Info'
	2. [ ] editing?
	3. [x] collapsible
	4. [x] UI awkward with Add Entry below