### PR TITLE
replace <pre> with vue-showdown to render markdown in non-edit mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "dropbox": "^10.34.0",
         "pinia": "^2.1.4",
         "qs": "^6.12.1",
+        "showdown": "^2.1.0",
         "vue": "^3.2.47",
+        "vue-showdown": "^4.2.0",
         "vue-spinner": "^1.0.4"
       },
       "devDependencies": {
@@ -148,6 +150,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
       "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/showdown": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
+      "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
@@ -480,6 +488,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/cross-fetch": {
@@ -1312,6 +1329,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -1657,6 +1690,20 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/vue-showdown": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vue-showdown/-/vue-showdown-4.2.0.tgz",
+      "integrity": "sha512-2/daUw8TsMFCAb+6yRC87eM4U/B/vp/oCWPbSlUSNbttKitIiQ7NCDRVzhjPmNVIzzToEBnQNonZEE5ZJyTzIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/showdown": "^2.0.1",
+        "showdown": "^2.1.0",
+        "vue": "^3.3.4"
+      },
+      "engines": {
+        "node": ">=16.19.0"
       }
     },
     "node_modules/vue-spinner": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "dropbox": "^10.34.0",
     "pinia": "^2.1.4",
     "qs": "^6.12.1",
+    "showdown": "^2.1.0",
     "vue": "^3.2.47",
+    "vue-showdown": "^4.2.0",
     "vue-spinner": "^1.0.4"
   },
   "devDependencies": {

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -56,7 +56,10 @@ function save(entry) {
   <div class="entry">
     <h3>{{ formattedDate }}</h3>
     <div v-if="!isEditing && !isEditingClick" @click="edit" class="entry__body">
-      <pre class="entry__pre">{{ entry.entry }}</pre>
+      <VueShowdown   
+        flavor="github"
+        :markdown="props.entry.entry" 
+      />
     </div>
 
     <!-- Display a textarea if editing -->

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -54,7 +54,7 @@ function save(entry) {
 
 <template>
   <div class="entry">
-    <h3>{{ formattedDate }}</h3>
+    <h3 class="date-entries">{{ formattedDate }}</h3>
     <div v-if="!isEditing && !isEditingClick" @click="edit" class="entry__body">
       <VueShowdown   
         flavor="github"
@@ -74,26 +74,28 @@ function save(entry) {
   </div>
 </template>
 
-<style scoped lang="stylus">
-h3 {
-  font-weight: 700;
-  font-size: 14px;
-  margin: 50px 0 20px 20px;
-}
+<style lang="styl">
 
-.entry__body {
-  background-color: var(--misc-color);
-}
+h3.date-entries 
+  font-weight 700
+  font-size 14px
+  margin 50px 0 20px 20px 
 
-.entry__pre
+.entry__body 
+  background-color: var(--misc-color)
+  ul 
+    padding-left 20px
+    list-style-type disc
+
+.entry__pre {
   white-space: pre-wrap;
-
+}
 .entry__body,
 .entry__textarea {
   font-size: 16px;
   font-family: var(--font);
-  width 100%
-  box-sizing border-box
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .entry__body,

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -54,7 +54,7 @@ function save(entry) {
 
 <template>
   <div class="entry">
-    <h3 class="date-entries">{{ formattedDate }}</h3>
+    <h3>{{ formattedDate }}</h3>
     <div v-if="!isEditing && !isEditingClick" @click="edit" class="entry__body">
       <VueShowdown   
         flavor="github"
@@ -75,17 +75,23 @@ function save(entry) {
 </template>
 
 <style lang="styl">
+.entry__body 
+  ul 
+    padding-left 20px
+    list-style-type disc
+</style>
 
-h3.date-entries 
+
+<style lang="styl" scoped>
+
+h3
   font-weight 700
   font-size 14px
   margin 50px 0 20px 20px 
 
 .entry__body 
   background-color: var(--misc-color)
-  ul 
-    padding-left 20px
-    list-style-type disc
+
 
 .entry__pre {
   white-space: pre-wrap;

--- a/src/main.js
+++ b/src/main.js
@@ -3,4 +3,6 @@ import App from './App.vue'
 
 const app = createApp(App)
 
+app.component('VueShowdown', VueShowdown);
 app.mount('#app')
+import { VueShowdown } from 'vue-showdown';

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,11 @@
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz"
   integrity sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==
 
+"@types/showdown@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz"
+  integrity sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==
+
 "@types/web-bluetooth@^0.0.17":
   version "0.0.17"
   resolved "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz"
@@ -287,6 +292,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^9.0.0:
+  version "9.5.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 cross-fetch@^4.0.0:
   version "4.0.0"
@@ -729,6 +739,13 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+showdown@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz"
+  integrity sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==
+  dependencies:
+    commander "^9.0.0"
+
 side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz"
@@ -854,12 +871,21 @@ vue-demi@>=0.14.5:
   resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz"
   integrity sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==
 
+vue-showdown@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/vue-showdown/-/vue-showdown-4.2.0.tgz"
+  integrity sha512-2/daUw8TsMFCAb+6yRC87eM4U/B/vp/oCWPbSlUSNbttKitIiQ7NCDRVzhjPmNVIzzToEBnQNonZEE5ZJyTzIg==
+  dependencies:
+    "@types/showdown" "^2.0.1"
+    showdown "^2.1.0"
+    vue "^3.3.4"
+
 vue-spinner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/vue-spinner/-/vue-spinner-1.0.4.tgz"
   integrity sha512-GNG2F+8BLX201JT/jUX+84Gsi3ZteVQwt9K7mues3ts9FcQ95dGn7uu6a5ndSxdYYUEzfh1KngZiOE0u+l4itA==
 
-"vue@^2.6.14 || ^3.3.0", "vue@^3.0.0-0 || ^2.6.0", vue@^3.2.25, vue@^3.2.47, vue@3.3.4:
+"vue@^2.6.14 || ^3.3.0", "vue@^3.0.0-0 || ^2.6.0", vue@^3.2.25, vue@^3.2.47, vue@^3.3.4, vue@3.3.4:
   version "3.3.4"
   resolved "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz"
   integrity sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==


### PR DESCRIPTION
This will display tasklists correctly but doesnt have the functionality to check a task. 
It does display correctly if you check a task in plain text in edit mode, so I think we can integrate this as an incremental step at least. 