### PR TITLE
refactored useFlogs so all UI components use it rather than useDropboxFlogs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <main :class="{ connected: hasConnection }">
-  <aside class="vue-file">App.vue</aside>
-    <Head /> 
+    <aside class="vue-file">App.vue</aside>
+    <Head />
 
     <Suspense>
       <Login />
@@ -15,9 +15,9 @@
     <div v-else>
       <div v-for="flog in openFlogs" :key="flog.url">
         <Flog :flog="flog" />
-      </div>  
+      </div>
     </div>
-    
+
     <div class="message"></div>
   </main>
 </template>
@@ -28,15 +28,12 @@ import Login from "@/components/Login.vue";
 import FlogList from "@/components/FlogList.vue";
 import Flog from "@/components/Flog.vue";
 import { useOpenFlogs } from "@/composables/useOpenFlogs.ts";
-import { useDropboxFlogs } from "@/composables/useDropboxFlogs.ts";
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource.ts";
 import Head from "@/components/Head.vue";
-const { hasConnection } = useDropboxFlogs();
+const { hasConnection } = useFlogSource(IFlogSourceType.dropbox);
 const ShowFlogList = ref(false);
 const { openFlogs } = useOpenFlogs();
-
-
 </script>
-
 
 <style>
 .message {

--- a/src/components/AddEntry.vue
+++ b/src/components/AddEntry.vue
@@ -78,7 +78,7 @@ const submitAdd = (event) => {
 
 // this watch is triggered when copying an entry
 watch(
-  props.entryValue,
+  () => props.entryValue,
   (newVal) => {
     if (!newVal || !newVal?.entry) {
       entryEl.value.innerText = "";

--- a/src/components/AddEntry.vue
+++ b/src/components/AddEntry.vue
@@ -78,7 +78,7 @@ const submitAdd = (event) => {
 
 // this watch is triggered when copying an entry
 watch(
-  () => props.entryValue,
+  props.entryValue,
   (newVal) => {
     if (!newVal || !newVal?.entry) {
       entryEl.value.innerText = "";

--- a/src/components/AddFlog.vue
+++ b/src/components/AddFlog.vue
@@ -1,5 +1,4 @@
 <template>
-
   <aside class="vue-file">AddFlog.vue</aside>
   <div v-if="!showInput">
     <button
@@ -12,34 +11,40 @@
       add new flog
     </button>
   </div>
-  <form v-else id="add-flog" @submit.prevent="submitAdd" @mouseleave="hideDropdown" @keydown="handleKeydown">
-      <div class="filename-controls">
-        <input
-          autofocus
-          autocomplete="off"
-          :class="['filename', { error: hasError }]"
-          id="filename"
-          type="text"
-          placeholder="search or create new flog"
-          v-model="typedFilename"
-          @focus="showDropdown = true"
-          @input="showDropdown = true"
-        />
-        <!-- required
+  <form
+    v-else
+    id="add-flog"
+    @submit.prevent="submitAdd"
+    @mouseleave="hideDropdown"
+    @keydown="handleKeydown"
+  >
+    <div class="filename-controls">
+      <input
+        autofocus
+        autocomplete="off"
+        :class="['filename', { error: hasError }]"
+        id="filename"
+        type="text"
+        placeholder="search or create new flog"
+        v-model="typedFilename"
+        @focus="showDropdown = true"
+        @input="showDropdown = true"
+      />
+      <!-- required
           @change="change" -->
-        <div class="autoc-select" v-show="showDropdown">
-          <ul id="files">
-            <li v-for="item in matchedFlogs">
-              <a href="#" @click.prevent="() => selectFlog(item)">{{
-                item.path_display ?? item.url
-              }}</a>
-            </li>
-          </ul>
-        </div>
-        <em class="date-validation hidden" :class="{ error: hasError }"
-          >Please enter valid file name</em
-        >
+      <div class="autoc-select" v-show="showDropdown">
+        <ul id="files">
+          <li v-for="item in matchedFlogs">
+            <a href="#" @click.prevent="() => selectFlog(item)">{{
+              item.path_display ?? item.url
+            }}</a>
+          </li>
+        </ul>
       </div>
+      <em class="date-validation hidden" :class="{ error: hasError }"
+        >Please enter valid file name</em
+      >
+    </div>
   </form>
 </template>
 
@@ -102,7 +107,7 @@ const hideDropdown = () => {
 };
 
 const handleKeydown = (e) => {
-  if (e.key === 'Escape') {
+  if (e.key === "Escape") {
     showDropdown.value = false;
   }
 };
@@ -110,20 +115,20 @@ const handleKeydown = (e) => {
 
 <style scoped lang="stylus">
 
-.autoc-select ul 
+.autoc-select ul
   list-style none
   box-shadow 0 2px 4px rgba(0, 0, 0, 0.1)
   background-color var(--input-color)
   margin 0
   padding 0
-  a 
-    padding 10px 15px    
+  a
+    padding 10px 15px
     display block
-    &:hover 
+    &:hover
       background-color var(--input-color)
-    
 
-input.error 
+
+input.error
   border: 1px solid red;
 
 
@@ -137,15 +142,15 @@ input[type="button"] {
   cursor: pointer;
 }
 
-.filename-controls 
+.filename-controls
     position: relative;
-  
-.filename 
+
+.filename
   background-color: var(--input-color);
   padding 20px
   border-radius: 14px
   font-weight: bold;
-  border-color: lightsteelblue 
+  border-color: lightsteelblue
   border-style solid
   font-size: 16px;
   outline-color: var(--input-color)
@@ -155,10 +160,10 @@ input[type="button"] {
   @media screen and (min-width: 600px)
     max-width: 600px
 
-  &:focus 
+  &:focus
     Xbox-shadow: 0 0 10px rgba(0, 0, 0, 0.5)
     Xborder-color transparent
-    
+
 
 .autoc-select {
   position: absolute;

--- a/src/components/DropBoxAuth.vue
+++ b/src/components/DropBoxAuth.vue
@@ -6,12 +6,12 @@
 </template>
 
 <script setup>
-import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource.ts";
 
-// Calling useDropboxFlogs to handle the auth flow,
+// Calling useFlogSource to handle the flow to check authentication,
 // but don't need to use any vars or functions from it,
 // so just calling it without the usual const destructuring assignments
-useDropboxFlogs();
+useFlogSource(IFlogSourceType.dropbox);
 
 </script>
 

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -110,8 +110,6 @@ function handleBlur(event) {
   // // This is not necessary and triggers a re-render on focus
 }
 
-
-
 // what do these watches do?
 
 watch(

--- a/src/components/Flog.vue
+++ b/src/components/Flog.vue
@@ -44,11 +44,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, unref, computed } from "vue";
+import { ref, unref } from "vue";
 import { useOpenFlogs } from "@/composables/useOpenFlogs";
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource";
 import { useFlog, IFlogStatus } from "@/composables/useFlog";
+import type { IFlog } from "@/composables/useFlog";
 import EntryData, { IEntry } from "@/modules/EntryData";
-import type { IFlog } from "@/modules/Flog";
 import AddEntry from "@/components/AddEntry.vue";
 import EntryList from "@/components/EntryList.vue";
 import Pretext from "@/components/Pretext.vue";
@@ -60,8 +61,11 @@ const props = defineProps<{
 
 const {
   closeFlog,
-  saveFlogToSource,
 } = useOpenFlogs();
+
+const {
+  saveFlogToSource,
+} = useFlogSource(IFlogSourceType.dropbox);
 
 const {
   addEntry,

--- a/src/components/FlogList.vue
+++ b/src/components/FlogList.vue
@@ -4,7 +4,7 @@
     <div
       id="authed-section"
       :style="{
-        display: hasConnection.get(IFlogSourceType.dropbox) ? 'block' : 'none',
+        display: hasConnection ? 'block' : 'none',
       }"
     >
       <AddFlog
@@ -70,7 +70,11 @@
 </template>
 
 <script setup lang="ts">
-import { useFlogs, IFlog, IFlogSourceType } from "@/composables/useFlogs";
+import {
+  useFlogSource,
+  IFlog,
+  IFlogSourceType,
+} from "@/composables/useFlogSource";
 // @ts-ignore-error
 import { useOpenFlogs } from "@/composables/useOpenFlogs";
 import AddFlog from "@/components/AddFlog.vue";
@@ -84,7 +88,7 @@ const {
   loadFlogEntriesFromSource,
   addFlogToSource,
   deleteFlogFromSource,
-} = useFlogs();
+} = useFlogSource(IFlogSourceType.dropbox);
 
 const { openFlog } = useOpenFlogs();
 
@@ -94,19 +98,17 @@ const defaultFlogAlreadyOpened = ref(
 const defaultFlogFilepath = "/default.flogger.txt";
 
 const showModal = ref(false);
-watch([() => [...connectionPopupWindow.value]], () => {
-  showModal.value = connectionPopupWindow.value.get(IFlogSourceType.dropbox)
-    ? true
-    : false;
-});
+watch(
+  connectionPopupWindow,
+  () => {
+    showModal.value = connectionPopupWindow.value ? true : false;
+  }
+);
 
 watch(
-  [() => [...hasConnection.value], () => [...availableFlogs.value]],
+  [hasConnection, availableFlogs],
   () => {
-    if (
-      hasConnection.value.get(IFlogSourceType.dropbox) &&
-      !defaultFlogAlreadyOpened.value
-    ) {
+    if (hasConnection.value && !defaultFlogAlreadyOpened.value) {
       const defaultFlogFile = availableFlogs.value.filter(
         (flog) =>
           flog.sourceType == IFlogSourceType.dropbox &&
@@ -164,7 +166,7 @@ const sortDescending = ref<boolean>(true);
 
 const showSortOptionSelect = ref(false);
 function selectSortOption(option: sortType) {
-  console.log('selectSortOption',option)
+  console.log("selectSortOption", option);
   sortOption.value = option;
 }
 
@@ -200,9 +202,9 @@ const sortedAvailableFlogs = ref(
   sortFlogsByModified(availableFlogs.value, true)
 );
 watch(
-  [() => [...availableFlogs.value], sortOption, sortDescending],
+  [availableFlogs, sortOption, sortDescending],
   () => {
-    console.log('sortOption.value', sortOption.value)
+    console.log("sortOption.value", sortOption.value);
     switch (sortOption.value) {
       case sortType.name:
         sortedAvailableFlogs.value = sortFlogsByFilename(

--- a/src/components/FlogList.vue
+++ b/src/components/FlogList.vue
@@ -73,7 +73,7 @@ import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
 import { useOpenFlogs } from "@/composables/useOpenFlogs";
 import AddFlog from "@/components/AddFlog.vue";
 import { ref, watch } from "vue";
-import { IFlog } from "@/modules/Flog";
+import { IFlog, IFlogSourceType } from "@/modules/Flog";
 
 const {
   connectionPopupWindow,
@@ -130,7 +130,7 @@ function handleAddFlog(flogData) {
     url: flogData.value.filename + ".flogger.txt",
     loadedEntries: [],
     rev: null,
-    sourceType: "dropbox",
+    sourceType: IFlogSourceType.dropbox,
   });
 }
 

--- a/src/components/Head.vue
+++ b/src/components/Head.vue
@@ -1,58 +1,72 @@
 <template>
-    <header>
-      <input class="btn-prefs" type="image" src="/icon-gear.svg" />
-      <dialog ref="dialog">
-        <div class="theme-controls">
+  <header>
+    <input class="btn-prefs" type="image" src="/icon-gear.svg" />
+    <dialog ref="dialog">
+      <div class="theme-controls">
+        <ThemeSwitcher />
 
-          <ThemeSwitcher />
-          
-          <div
-            id="authed-section"
-            :style="{ display: hasConnection ? 'block' : 'none' }"
-          >
-            <button class="dbx__btn small" @click="disconnect">
-              <img
-                alt="Dropbox account"
-                src="/Dropbox_Icon.svg"
-                width="16"
-                height="16"
-              />
-              Disconnect {{ accountOwner }}
-            </button>
-
-           <button class="small" @click="fileView">
-            {{ fileViewOn ? 'Turn off File view' : 'Turn on File view' }}
+        <div
+          id="authed-section"
+          :style="{
+            display: hasConnection.get(IFlogSourceType.dropbox)
+              ? 'block'
+              : 'none',
+          }"
+        >
+          <button class="dbx__btn small" @click="disconnect">
+            <img
+              alt="Dropbox account"
+              src="/Dropbox_Icon.svg"
+              width="16"
+              height="16"
+            />
+            Disconnect {{ accountOwnerValue }}
           </button>
-          </div>
-          <form method="dialog" class="text-center mt-8">
-              <button formmethod="dialog" class="small">Close</button>
-          </form>
-        </div>
-      </dialog>
 
-      <h1 id="logo">
-        <pre>
+          <button class="small" @click="fileView">
+            {{ fileViewOn ? "Turn off File view" : "Turn on File view" }}
+          </button>
+        </div>
+        <form method="dialog" class="text-center mt-8">
+          <button formmethod="dialog" class="small">Close</button>
+        </form>
+      </div>
+    </dialog>
+
+    <h1 id="logo">
+      <pre>
 ███████╗██╗      ██████╗  ██████╗  ██████╗ ███████╗██████╗ 
 ██╔════╝██║     ██╔═══██╗██╔════╝ ██╔════╝ ██╔════╝██╔══██╗
 █████╗  ██║     ██║   ██║██║  ███╗██║  ███╗█████╗  ██████╔╝
 ██╔══╝  ██║     ██║   ██║██║   ██║██║   ██║██╔══╝  ██╔══██╗
 ██║     ███████╗╚██████╔╝╚██████╔╝╚██████╔╝███████╗██║  ██║
 ╚═╝     ╚══════╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝
-        </pre>
-      </h1>
-    </header>
-
+        </pre
+      >
+    </h1>
+  </header>
 </template>
 
 <script setup>
-import { useDropboxFiles } from "@/composables/useDropboxFiles";
-import { useDropboxFlogs } from "@/composables/useDropboxFlogs.ts";
+import { onMounted, ref, watch } from "vue";
+import { useFlogs } from "@/composables/useFlogs.ts";
 import ThemeSwitcher from "@/components/ThemeSwitcher.vue";
-import { onMounted, ref } from "vue";
-const { hasConnection, accountOwner } = useDropboxFlogs();
-const { clearConnection } = useDropboxFlogs();
+import { IFlogSourceType } from "@/modules/Flog";
+
+const { hasConnection, accountOwner } = useFlogs();
+const { clearConnection } = useFlogs();
 const dialog = ref(null);
 const fileViewOn = ref(false);
+
+const accountOwnerValue = ref(null);
+
+watch(
+  [() => [...accountOwner.value]],
+  () => {
+    accountOwnerValue.value = accountOwner.value.get(IFlogSourceType.dropbox);
+  },
+  { immediate: true }
+);
 
 onMounted(() => {
   const modalBtn = document.querySelector(".btn-prefs");
@@ -65,23 +79,23 @@ onMounted(() => {
 });
 
 const disconnect = () => {
-  clearConnection();
+  clearConnection(IFlogSourceType.dropbox);
   dialog.value.close();
-}
+};
 
 const fileView = () => {
   fileViewOn.value = !fileViewOn.value;
   const fileElements = document.querySelectorAll(".vue-file");
-  fileElements.forEach(el => {
+  fileElements.forEach((el) => {
     const element = el;
     // Toggle display between "none" and "block"
     const currentDisplay = window.getComputedStyle(element).display;
     element.style.display = currentDisplay === "none" ? "block" : "none";
   });
-}
+};
 </script>
 
-<style scoped > 
+<style scoped>
 .btn-prefs {
   background-color: transparent;
   width: 20px;
@@ -110,7 +124,7 @@ dialog {
   background: var(--bg-color);
 }
 dialog::backdrop {
-  background-color: rgba(0,0,0,0.5);
+  background-color: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(2px);
 }
 </style>

--- a/src/components/Head.vue
+++ b/src/components/Head.vue
@@ -8,9 +8,7 @@
         <div
           id="authed-section"
           :style="{
-            display: hasConnection.get(IFlogSourceType.dropbox)
-              ? 'block'
-              : 'none',
+            display: hasConnection ? 'block' : 'none',
           }"
         >
           <button class="dbx__btn small" @click="disconnect">
@@ -49,21 +47,22 @@
 
 <script setup>
 import { onMounted, ref, watch } from "vue";
-import { useFlogs } from "@/composables/useFlogs.ts";
+import { useFlogSource } from "@/composables/useFlogSource";
 import ThemeSwitcher from "@/components/ThemeSwitcher.vue";
 import { IFlogSourceType } from "@/modules/Flog";
 
-const { hasConnection, accountOwner } = useFlogs();
-const { clearConnection } = useFlogs();
+const { hasConnection, accountOwner, clearConnection } = useFlogSource(
+  IFlogSourceType.dropbox
+);
 const dialog = ref(null);
 const fileViewOn = ref(false);
 
-const accountOwnerValue = ref(null);
+const accountOwnerValue = ref(accountOwner.value);
 
 watch(
-  [() => [...accountOwner.value]],
+  accountOwner,
   () => {
-    accountOwnerValue.value = accountOwner.value.get(IFlogSourceType.dropbox);
+    accountOwnerValue.value = accountOwner.value;
   },
   { immediate: true }
 );
@@ -79,7 +78,7 @@ onMounted(() => {
 });
 
 const disconnect = () => {
-  clearConnection(IFlogSourceType.dropbox);
+  clearConnection();
   dialog.value.close();
 };
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -17,6 +17,6 @@
 </template>
 
 <script setup>
-import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
-const { launchConnectFlow } = useDropboxFlogs();
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource.ts";
+const { launchConnectFlow } = useFlogSource(IFlogSourceType.dropbox);
 </script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -38,10 +38,7 @@
 
 <script setup>
 import { IFlogSourceType, useFlogSource } from "@/composables/useFlogSource";
-import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
 import { useOpenFlogs } from "@/composables/useOpenFlogs";
-import AddFlog from "@/components/AddFlog.vue";
-// const { accountInfo } = useDropboxFiles();
 import { ref, watch } from "vue";
 import Modal from "@/components/Modal.vue";
 import Intro from "@/components/Intro.vue";

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -9,10 +9,7 @@
       <template #body>
         <p>
           Complete the Dropbox authorization
-          <a
-            @click="connectionPopupWindow.get(IFlogSourceType.dropbox)?.focus()"
-            >in the pop-up window</a
-          >.
+          <a @click="connectionPopupWindow?.focus()">in the pop-up window</a>.
         </p>
         <p>
           If the window doesn't pop-up, <a @click="openPop()">click here</a>.
@@ -31,7 +28,7 @@
     <div
       id="pre-auth-section"
       :style="{
-        display: hasConnection.get(IFlogSourceType.dropbox) ? 'none' : 'block',
+        display: hasConnection ? 'none' : 'block',
       }"
     >
       <Intro />
@@ -40,7 +37,7 @@
 </template>
 
 <script setup>
-import { IFlogSourceType, useFlogs } from "@/composables/useFlogs";
+import { IFlogSourceType, useFlogSource } from "@/composables/useFlogSource";
 import { useDropboxFlogs } from "@/composables/useDropboxFlogs";
 import { useOpenFlogs } from "@/composables/useOpenFlogs";
 import AddFlog from "@/components/AddFlog.vue";
@@ -56,7 +53,7 @@ const {
   availableFlogs,
   loadFlogEntriesFromSource,
   addFlog,
-} = useFlogs();
+} = useFlogSource(IFlogSourceType.dropbox);
 
 const { openFlog } = useOpenFlogs();
 // const props = defineProps({});
@@ -68,18 +65,16 @@ const defaultFlogFilepath = "/default.flogger.txt";
 
 const showModal = ref(false);
 watch(
-  () => [...connectionPopupWindow.value],
+  connectionPopupWindow,
   () => {
-    showModal.value = connectionPopupWindow.value.get(IFlogSourceType.dropbox)
-      ? true
-      : false;
+    showModal.value = connectionPopupWindow.value ? true : false;
   },
   { immediate: true }
 );
 
 const openPop = () => {
-  console.log("openPop", openPopup(IFlogSourceType.dropbox));
-  openPopup(IFlogSourceType.dropbox);
+  console.log("openPop", openPopup());
+  openPopup();
 };
 
 const selectFile = (file) => {
@@ -89,12 +84,9 @@ const selectFile = (file) => {
 };
 
 watch(
-  [() => [...hasConnection.value], availableFlogs],
+  [hasConnection, availableFlogs],
   () => {
-    if (
-      hasConnection.value.get(IFlogSourceType.dropbox) &&
-      !defaultFlogAlreadyOpened.value
-    ) {
+    if (hasConnection.value && !defaultFlogAlreadyOpened.value) {
       const defaultFlogFile = availableFlogs.value.filter(
         (file) => file.url == defaultFlogFilepath
       )[0];

--- a/src/composables/useDropboxFiles.ts
+++ b/src/composables/useDropboxFiles.ts
@@ -16,7 +16,7 @@ export interface IDropboxFiles {
     accountInfo: Ref<string | null>
     launchConnectFlow: () => void
     openDbxPopup: () => void
-    connectionPopupWindow: any
+    connectionPopupWindow: Ref<any>
     hasConnection: Ref<boolean>
     clearConnection: () => void
     availableFiles: Ref<IDropboxFile[]>

--- a/src/composables/useDropboxFlogs.ts
+++ b/src/composables/useDropboxFlogs.ts
@@ -16,7 +16,7 @@ export interface IDropboxFlogs {
     // pass through from useDropboxFiles
     launchConnectFlow: () => void;
     // pass through from useDropboxFiles
-    connectionPopupWindow: boolean;
+    connectionPopupWindow: Ref<any>;
     openDbxPopup: () => void;
     // pass through from useDropboxFiles
     hasConnection: Ref<boolean>;

--- a/src/composables/useDropboxFlogs.ts
+++ b/src/composables/useDropboxFlogs.ts
@@ -1,6 +1,6 @@
 import { ref, Ref, watch, onUpdated, onActivated } from "vue"
 import type { IFlog } from "@/modules/Flog"
-import { IFlogStatus, deserializeFlog, serializeFlog } from "@/modules/Flog"
+import { IFlogStatus, IFlogSourceType, deserializeFlog, serializeFlog } from "@/modules/Flog"
 import { useDropboxFiles } from "@/composables/useDropboxFiles"
 import { IDropboxFile } from "@/composables/useDropboxFiles";
 import { timestamp, useTimestamp } from "@vueuse/core";
@@ -140,10 +140,10 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
             // // Rather than merging the old and new values with this...
             // const removed = !oldValue ? [] : oldValue
             //     .filter((file) => newValue && !newValue.includes(file))
-            //     .map<IDropboxFlog>((file) => ({ sourceType: 'dropbox', url: file.path } as IDropboxFlog))
+            //     .map<IDropboxFlog>((file) => ({ sourceType: IFlogSourceType.dropbox, url: file.path } as IDropboxFlog))
             // const added = !newValue ? [] : newValue
             //     .filter((file) => oldValue && !oldValue.includes(file))
-            //     .map<IDropboxFlog>((file) => ({ sourceType: 'dropbox', url: file.path } as IDropboxFlog))
+            //     .map<IDropboxFlog>((file) => ({ sourceType: IFlogSourceType.dropbox, url: file.path } as IDropboxFlog))
             // // console.log('watching newValue', removed, added, availableFlogs)
             // const comparableAvailableFlogs = availableFlogs.value.map((flog) => ({ sourceType: flog.sourceType, url: flog.url } as IDropboxFlog))
             // availableFlogs.value = comparableAvailableFlogs
@@ -155,7 +155,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
             // // We will just recreate availableFlogs with this...
             availableFlogs.value = availableFiles.value.map<IDropboxFlog>(
                 (file) => ({
-                    sourceType: 'dropbox',
+                    sourceType: IFlogSourceType.dropbox,
                     url: file.path,
                     modified: new Date(file.modified),
                     rev: null,
@@ -172,7 +172,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
         (newValue, oldValue) => {
             // console.log('watch availableRepoFiles (useDropboxFlogs)', availableRepoFlogs.value, availableRepoFiles, newValue, oldValue)
             availableRepoFlogs.value = availableRepoFiles.value.map<IDropboxFlog>(
-                (file) => ({ sourceType: 'dropbox', url: file.path, readOnly: file.readOnly } as IDropboxFlog)
+                (file) => ({ sourceType: IFlogSourceType.dropbox, url: file.path, readOnly: file.readOnly } as IDropboxFlog)
             )
         }
         ,
@@ -253,7 +253,7 @@ export const useDropboxFlogs = (): IDropboxFlogs => {
         loadFlogEntries,
         saveFlogEntries,
         addFlog,
-        deleteFlog, 
+        deleteFlog,
         accountOwner: accountOwner
     }
 }

--- a/src/composables/useFlog.ts
+++ b/src/composables/useFlog.ts
@@ -2,7 +2,7 @@ import { ref, Ref, toValue } from "vue"
 import type { IFlog } from "@/modules/Flog"
 import { IFlogStatus } from "@/modules/Flog"
 import { IEntry } from '@/modules/EntryData'
-import { useOpenFlogs } from "@/composables/useOpenFlogs"
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource"
 
 // Re-export these for convenience
 export type { IFlog as IFlog }
@@ -16,7 +16,7 @@ interface IUseFlog {
     editEntry: (entry: IEntry) => void;
 }
 
-const { saveFlogToSource } = useOpenFlogs();
+const { saveFlogToSource } = useFlogSource(IFlogSourceType.dropbox);
 
 export function useKeyDownHandler(blurCallback: (event: KeyboardEvent) => void) {
     function handleKeyDown(event: KeyboardEvent) {

--- a/src/composables/useFlog.ts
+++ b/src/composables/useFlog.ts
@@ -8,6 +8,11 @@ import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource"
 export type { IFlog as IFlog }
 export { IFlogStatus as IFlogStatus }
 
+// useFlog returns the refs and operations defined in IFlog 
+// It includes:
+//  - a refs for the flog
+//  - operations for updating the parts of the flog ref (add, udpate, delete entries, and update pretext)
+
 interface IUseFlog {
     flog: Ref<IFlog>;
     addEntry: (entry: IEntry) => void;

--- a/src/composables/useFlog.ts
+++ b/src/composables/useFlog.ts
@@ -19,20 +19,21 @@ interface IUseFlog {
     updatePretext: (pretext: string) => void;
     deleteEntry: (entry: IEntry) => void;
     editEntry: (entry: IEntry) => void;
+    useKeyDownHandler: (blurCallback: (event: KeyboardEvent) => void) => { handleKeyDown: (event: KeyboardEvent) => void };
 }
 
 const { saveFlogToSource } = useFlogSource(IFlogSourceType.dropbox);
 
 export function useKeyDownHandler(blurCallback: (event: KeyboardEvent) => void) {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.shiftKey && event.key === "Enter") {
-        event.preventDefault();
-        blurCallback(event);
-        (event.target as HTMLElement)?.blur();
-      }
+        if (event.shiftKey && event.key === "Enter") {
+            event.preventDefault();
+            blurCallback(event);
+            (event.target as HTMLElement)?.blur();
+        }
     }
     return { handleKeyDown };
-  }
+}
 
 export const useFlog = (inFlog: IFlog | Ref<IFlog>): IUseFlog => {
 

--- a/src/composables/useFlogSource.ts
+++ b/src/composables/useFlogSource.ts
@@ -103,36 +103,73 @@ const {
 } = useDropboxFlogs();
 
 
-export const useFlogSource = (sourceType: IFlogSourceType): IFlogSource => {
+// Defining all ref variables at the module scope 
+// (meaning at the root of this module file, 
+// outside of the useComposable function that gets called by the importer),
+// Creating ref variables at module scope makes them singletons shared by all composable importers.
+// Otherwise, each composable importer gets its own instances of each ref variable.
+// See https://vuejs.org/guide/scaling-up/state-management#simple-state-management-with-reactivity-api
+// Using module-scoped state requires special handling with SSR, if we ever want SSR.
+// See https://vuejs.org/guide/scaling-up/state-management#simple-state-management-with-reactivity-api
+const availableFlogs = ref<IFlog[]>([]);
+const availableRepoFlogs = ref<IFlog[]>([]);
+const accountOwner = ref<string | null>(null);
+const hasConnection = ref<boolean>(false);
+const connectionPopupWindow = ref<any>();
 
-    const availableFlogs = ref<IFlog[]>([]);
-    watch(
-        availableFlogs_dropbox,
-        () => {
-            // replace dropbox flogs...
-            availableFlogs.value = availableFlogs.value
-                // first filtering existing out, 
-                .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
-                // then adding latest.
-                .concat(availableFlogs_dropbox.value)
-        }
-        ,
-        { immediate: true }
-    )
-    const availableRepoFlogs = ref<IFlog[]>([]);
-    watch(
-        availableRepoFlogs_dropbox,
-        () => {
-            // replace dropbox flogs...
-            availableRepoFlogs.value = availableRepoFlogs.value
-                // first filtering existing out, 
-                .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
-                // then adding latest.
-                .concat(availableRepoFlogs_dropbox.value)
-        }
-        ,
-        { immediate: true }
-    )
+// Ref variables that are passed through from a specific use[Source]Flogs composable
+// need watchers on source variables
+watch(
+    availableFlogs_dropbox,
+    () => {
+        // replace dropbox flogs...
+        availableFlogs.value = availableFlogs.value
+            // first filtering existing out, 
+            .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
+            // then adding latest.
+            .concat(availableFlogs_dropbox.value)
+    }
+    ,
+    { immediate: true }
+)
+watch(
+    availableRepoFlogs_dropbox,
+    () => {
+        // replace dropbox flogs...
+        availableRepoFlogs.value = availableRepoFlogs.value
+            // first filtering existing out, 
+            .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
+            // then adding latest.
+            .concat(availableRepoFlogs_dropbox.value)
+    }
+    ,
+    { immediate: true }
+)
+watch(accountOwner_dropbox,
+    () => {
+        console.log('watch accountOwner_dropbox', accountOwner_dropbox)
+        accountOwner.value = accountOwner_dropbox.value
+    },
+    { immediate: true }
+)
+watch(hasConnection_dropbox,
+    () => {
+        console.log('watch hasConnection_dropbox', hasConnection_dropbox)
+        hasConnection.value = hasConnection_dropbox.value
+    },
+    { immediate: true }
+)
+watch(connectionPopupWindow_dropbox,
+    () => {
+        console.log('watch connectionPopupWindow_dropbox', connectionPopupWindow_dropbox)
+        connectionPopupWindow.value = connectionPopupWindow_dropbox.value
+    },
+    { immediate: true }
+)
+
+
+
+export const useFlogSource = (sourceType: IFlogSourceType): IFlogSource => {
 
     const addFlogToSource = (flog: IFlog) => {
         switch (flog.sourceType) {
@@ -170,18 +207,10 @@ export const useFlogSource = (sourceType: IFlogSourceType): IFlogSource => {
         }
     }
 
-    const accountOwner = ref<string | null>(null);
-    watch(accountOwner_dropbox,
-        () => {
-            console.log('watch accountOwner_dropbox', accountOwner_dropbox)
-            accountOwner.value = accountOwner_dropbox.value
-        },
-        { immediate: true }
-    )
-
     const launchConnectFlow = () => {
         switch (sourceType) {
             case IFlogSourceType.dropbox:
+                launchConnectFlow_dropbox();
                 break;
             default:
         }
@@ -204,25 +233,6 @@ export const useFlogSource = (sourceType: IFlogSourceType): IFlogSource => {
             default:
         }
     }
-
-    const hasConnection = ref<boolean>(false);
-    watch(hasConnection_dropbox,
-        () => {
-            console.log('watch hasConnection_dropbox', hasConnection_dropbox)
-            hasConnection.value = hasConnection_dropbox.value
-        },
-        { immediate: true }
-    )
-
-    const connectionPopupWindow = ref<any>();
-    watch(connectionPopupWindow_dropbox,
-        () => {
-            console.log('watch connectionPopupWindow_dropbox', connectionPopupWindow_dropbox)
-            connectionPopupWindow.value = connectionPopupWindow_dropbox.value
-        },
-        { immediate: true }
-    )
-
 
     return {
         availableFlogs,

--- a/src/composables/useFlogSource.ts
+++ b/src/composables/useFlogSource.ts
@@ -35,15 +35,6 @@ export interface IFlogs {
     saveFlogToSource: (flog: IFlog) => void;
     deleteFlogFromSource: (flog: IFlog) => void;
 
-    // *************
-    // FLOG CONTENTS
-    // *************
-
-    updatePretext: (pretext: string, flog: IFlog) => void;
-    addEntryToFlog: (entry: IEntry, flog: IFlog) => void;
-    editEntryFromFlog: (flog: IFlog, entry: IEntry) => void;
-    deleteEntryFromFlog: (flog: IFlog, entry: IEntry) => void;
-
     // **************
     // SOURCE ACCOUNT
     // **************
@@ -55,7 +46,7 @@ export interface IFlogs {
     accountOwner: Ref<string | null>;
 
     // *****************
-    // SOURCE OPERATIONS
+    // SOURCE CONNECTION OPERATIONS
     // *****************
 
     // useFlogSource provides the following source operations
@@ -168,49 +159,6 @@ export const useFlogSource = (sourceType: IFlogSourceType): IFlogs => {
         }
     }
 
-    const updatePretext = (pretext: string, flog: IFlog) => {
-        flog.pretext = pretext
-    }
-
-    const addEntryToFlog = (entry: IEntry, flog: IFlog) => {
-        flog.loadedEntries.unshift(entry)
-    }
-
-    const editEntryFromFlog = (flog: IFlog, entry: IEntry) => {
-        if (!flog || !Array.isArray(flog.loadedEntries)) {
-            console.error(`Flog or flog.loadedEntries is undefined or not an array: ${flog}`);
-            return;
-        }
-        // Find the index of the entry to delete
-        const editEntryIndex = flog.loadedEntries.findIndex(flogEntry => flogEntry.id === entry.id);
-        if (editEntryIndex !== -1) {
-            // Update the entry at the found index
-            flog.loadedEntries[editEntryIndex] = { ...flog.loadedEntries[editEntryIndex], ...entry };
-            // Save the updated flog to the source to persist the changes
-            saveFlogToSource(flog);
-        } else {
-            console.error('Entry not found in flog.loadedEntries');
-        }
-    }
-
-    const deleteEntryFromFlog = (flog: IFlog, entry: IEntry) => {
-        if (!flog || !Array.isArray(flog.loadedEntries)) {
-            console.error('Flog or flog.loadedEntries is undefined or not an array');
-            return;
-        }
-        // Find the index of the entry to delete
-        const deleteEntryIndex = flog.loadedEntries.findIndex(flogEntry => flogEntry.id === entry.id);
-        if (deleteEntryIndex !== -1) {
-            // Remove the entry
-            flog.loadedEntries.splice(deleteEntryIndex, 1);
-
-            // Save the updated flog to the source to persist the changes
-            saveFlogToSource(flog);
-        } else {
-            console.error('Entry not found in flog.loadedEntries');
-        }
-    };
-
     const accountOwner = ref<string | null>(null);
     watch(accountOwner_dropbox,
         () => {
@@ -273,11 +221,6 @@ export const useFlogSource = (sourceType: IFlogSourceType): IFlogs => {
         loadFlogEntriesFromSource,
         saveFlogToSource,
         deleteFlogFromSource,
-
-        addEntryToFlog,
-        updatePretext,
-        editEntryFromFlog,
-        deleteEntryFromFlog,
 
         accountOwner,
 

--- a/src/composables/useFlogSource.ts
+++ b/src/composables/useFlogSource.ts
@@ -9,7 +9,14 @@ export type { IFlog as IFlog }
 export { IFlogStatus as IFlogStatus }
 export { IFlogSourceType as IFlogSourceType }
 
-export interface IFlogs {
+// useFlogSource returns the refs and operations defined in IFlogSource
+// It includes:
+//  - refs for available flogs
+//  - operations for flogs at the source (add, load, save, delete)
+//  - a ref for the accountOwner
+//  - refs and operations for the connection to the source
+
+export interface IFlogSource {
 
     // ***************
     // AVAILABLE FLOGS
@@ -21,6 +28,10 @@ export interface IFlogs {
     // useFlogSource provides and manages one array for all available repo flogs 
     // from all sources.
     availableRepoFlogs: Ref<IFlog[]>;
+
+    // ***************
+    // FLOG OPERATIONS
+    // ***************
 
     // useFlogSource provides the following flog operations
     //      add, delete
@@ -45,9 +56,9 @@ export interface IFlogs {
     // useSourceType(sourceType).
     accountOwner: Ref<string | null>;
 
-    // *****************
+    // ****************************
     // SOURCE CONNECTION OPERATIONS
-    // *****************
+    // ****************************
 
     // useFlogSource provides the following source operations
     //      launchConnectFlow, openPopup, clearConnection
@@ -92,7 +103,7 @@ const {
 } = useDropboxFlogs();
 
 
-export const useFlogSource = (sourceType: IFlogSourceType): IFlogs => {
+export const useFlogSource = (sourceType: IFlogSourceType): IFlogSource => {
 
     const availableFlogs = ref<IFlog[]>([]);
     watch(

--- a/src/composables/useFlogs.ts
+++ b/src/composables/useFlogs.ts
@@ -1,12 +1,13 @@
 import { ref, watch } from "vue"
 import type { IFlog } from "@/modules/Flog"
-import { IFlogStatus } from "@/modules/Flog"
+import { IFlogStatus, IFlogSourceType } from "@/modules/Flog"
 import { IEntry } from '@/modules/EntryData'
 import { useDropboxFlogs, IDropboxFlog } from "@/composables/useDropboxFlogs";
 
 // Re-export these for convenience
 export type { IFlog as IFlog }
 export { IFlogStatus as IFlogStatus }
+export { IFlogSourceType as IFlogSourceType }
 
 const {
     saveFlogEntries: saveFlogEntries_dropbox,
@@ -92,7 +93,7 @@ export const useFlogs = () => {
 
     const saveFlogToSource = (flog: IFlog) => {
         switch (flog.sourceType) {
-            case 'dropbox':
+            case IFlogSourceType.dropbox:
                 saveFlogEntries_dropbox(flog as IDropboxFlog)
                 break;
             default:
@@ -101,7 +102,7 @@ export const useFlogs = () => {
 
     const addFlogToSource = (flog: IFlog) => {
         switch (flog.sourceType) {
-            case 'dropbox':
+            case IFlogSourceType.dropbox:
                 addFlog_dropbox(flog as IDropboxFlog)
                 break;
             default:

--- a/src/composables/useFlogs.ts
+++ b/src/composables/useFlogs.ts
@@ -1,4 +1,4 @@
-import { ref, watch } from "vue"
+import { ref, watch, Ref } from "vue"
 import type { IFlog } from "@/modules/Flog"
 import { IFlogStatus, IFlogSourceType } from "@/modules/Flog"
 import { IEntry } from '@/modules/EntryData'
@@ -9,10 +9,112 @@ export type { IFlog as IFlog }
 export { IFlogStatus as IFlogStatus }
 export { IFlogSourceType as IFlogSourceType }
 
+export interface IFlogs {
+
+    // ***************
+    // AVAILABLE FLOGS
+    // ***************
+
+    // useFlogs provides and manages one array for all available non-repo flogs 
+    // from all sources.
+    availableFlogs: Ref<IFlog[]>;
+    // useFlogs provides and manages one array for all available repo flogs 
+    // from all sources.
+    availableRepoFlogs: Ref<IFlog[]>;
+
+    // useFlogs provides the following flog operations
+    //      add, delete
+    // These map the operation to correct operation 
+    // for the flog's source
+    // 
+    // The following are functions that take a flog
+    // and call the appropriate pass through function
+    // from use[flog.sourceType]Flogs
+    addFlogToSource: (flog: IFlog) => void;
+    deleteFlogFromSource: (flog: IFlog) => void;
+
+    // ***************
+    // OPEN FLOGS
+    // ***************
+
+    // useFlogs provides and manages one array for all open flogs 
+    // from all sources.
+    openFlogs: Ref<IFlog[]>;
+
+    // useFlogs provides the following flog operations
+    //      add, delete
+    // These map the operation to correct operation 
+    // for the flog's source
+    // 
+    // The following are functions that take a flog
+    // and call the appropriate pass through function
+    // from use[flog.sourceType]Flogs
+    openFlog: (flog: IFlog) => void;
+    loadFlogEntriesFromSource: (flog: IFlog) => void;
+    saveFlogToSource: (flog: IFlog) => void;
+    closeFlog: (flog: IFlog) => void;
+
+    // *************
+    // FLOG CONTENTS
+    // *************
+
+    updatePretext: (pretext: string, flog: IFlog) => void;
+    addEntryToFlog: (entry: IEntry, flog: IFlog) => void;
+    editEntryFromFlog: (flog: IFlog, entry: IEntry) => void;
+    deleteEntryFromFlog: (flog: IFlog, entry: IEntry) => void;
+
+    // **************
+    // SOURCE ACCOUNT
+    // **************
+
+    // useFlogs provides a Map of accountOwners per source.
+    // Each value contains the pass through ref values from its 
+    // corresponding source.
+    accountOwner: Ref<Map<IFlogSourceType, string | null>>;
+
+    // *****************
+    // SOURCE OPERATIONS
+    // *****************
+
+    // useFlogs provides the following source operations
+    //      launchConnectFlow, openPopup, clearConnection
+    // These map the operation to correct operation 
+    // for the input SourceType.
+    // The naming of these could be improved, or generalized 
+    // to make sense for multiple sources. 
+    launchConnectFlow: (sourceType: IFlogSourceType) => void;
+    openPopup: (sourceType: IFlogSourceType) => void;
+    clearConnection: (sourceType: IFlogSourceType) => void;
+
+    // useFlogs provides a Map of hasConnection booleans per source.
+    // Each value contains the pass through ref values from its 
+    // corresponding source.
+    hasConnection: Ref<Map<IFlogSourceType, boolean>>;
+
+    // useFlogs provides a Map of connectionPopupWindows per source.
+    // Each value contains the pass through ref values from its 
+    // corresponding source.
+    // 
+    // The value of each connectionPopupWindow ref is the popup window object 
+    // for that source, when there is one open.
+    // Trying to access the window object properties while that window is 
+    // at a dropbox URL will throw CORS errors.
+    connectionPopupWindow: Ref<Map<IFlogSourceType, any>>;
+}
+
 const {
-    saveFlogEntries: saveFlogEntries_dropbox,
+    availableFlogs: availableFlogs_dropbox,
+    availableRepoFlogs: availableRepoFlogs_dropbox,
     addFlog: addFlog_dropbox,
-    availableFlogs: availableFlogs_dropbox
+    deleteFlog: deleteFlog_dropbox,
+    loadFlogEntries: loadFlogEntries_dropbox,
+    saveFlogEntries: saveFlogEntries_dropbox,
+    accountOwner: accountOwner_dropbox,
+    launchConnectFlow: launchConnectFlow_dropbox,
+    openDbxPopup: openDbxPopup_dropbox,
+    clearConnection: clearConnection_dropbox,
+    hasConnection: hasConnection_dropbox,
+    connectionPopupWindow: connectionPopupWindow_dropbox,
 } = useDropboxFlogs();
 
 
@@ -21,8 +123,8 @@ const {
 const openFlogs = ref<IFlog[]>([])
 
 watch(availableFlogs_dropbox, () => {
-    // if availableFlogs changes, filter out any openFlogs 
-    // that are no longer in availableFlogs
+    // if availableFlogs_dropbox changes, filter out any openFlogs 
+    // that are no longer in availableFlogs_dropbox
     if (openFlogs.value.length > 0) {
         const newOpenFlogs = openFlogs.value.filter(flog => {
             return availableFlogs_dropbox.value.reduce((p, c) => {
@@ -33,14 +135,79 @@ watch(availableFlogs_dropbox, () => {
     }
 })
 
-export const useFlogs = () => {
 
-    const openFlog = (newFlog: IFlog,) => {
-        if (!openFlogs.value.includes(newFlog)) {
-            openFlogs.value.unshift(newFlog)
+export const useFlogs = (): IFlogs => {
+
+    const availableFlogs = ref<IFlog[]>([]);
+    watch(
+        availableFlogs_dropbox,
+        () => {
+            // replace dropbox flogs...
+            availableFlogs.value = availableFlogs.value
+                // first filtering existing out, 
+                .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
+                // then adding latest.
+                .concat(availableFlogs_dropbox.value)
+        }
+        ,
+        { immediate: true }
+    )
+    const availableRepoFlogs = ref<IFlog[]>([]);
+    watch(
+        availableRepoFlogs_dropbox,
+        () => {
+            // replace dropbox flogs...
+            availableRepoFlogs.value = availableRepoFlogs.value
+                // first filtering existing out, 
+                .filter((flog) => flog.sourceType != IFlogSourceType.dropbox)
+                // then adding latest.
+                .concat(availableRepoFlogs_dropbox.value)
+        }
+        ,
+        { immediate: true }
+    )
+
+    const addFlogToSource = (flog: IFlog) => {
+        switch (flog.sourceType) {
+            case IFlogSourceType.dropbox:
+                addFlog_dropbox(flog as IDropboxFlog)
+                break;
+            default:
         }
     }
 
+    const deleteFlogFromSource = (flog: IFlog) => {
+        switch (flog.sourceType) {
+            case IFlogSourceType.dropbox:
+                deleteFlog_dropbox(flog as IDropboxFlog)
+                break;
+            default:
+        }
+    }
+
+    const openFlog = (flog: IFlog,) => {
+        if (!openFlogs.value.includes(flog)) {
+            openFlogs.value.unshift(flog)
+        }
+    }
+
+    const loadFlogEntriesFromSource = (flog: IFlog) => {
+        switch (flog.sourceType) {
+            case IFlogSourceType.dropbox:
+                loadFlogEntries_dropbox(flog as IDropboxFlog)
+                break;
+            default:
+        }
+    }
+
+    const saveFlogToSource = (flog: IFlog) => {
+        switch (flog.sourceType) {
+            case IFlogSourceType.dropbox:
+                saveFlogEntries_dropbox(flog as IDropboxFlog)
+                break;
+            default:
+        }
+    }
 
     const closeFlog = (flog: IFlog) => {
         if (openFlogs.value.includes(flog)) {
@@ -48,12 +215,29 @@ export const useFlogs = () => {
         }
     }
 
+    const updatePretext = (pretext: string, flog: IFlog) => {
+        flog.pretext = pretext
+    }
+
     const addEntryToFlog = (entry: IEntry, flog: IFlog) => {
         flog.loadedEntries.unshift(entry)
     }
 
-    const updatePretext = (pretext: string, flog: IFlog) => {
-        flog.pretext = pretext
+    const editEntryFromFlog = (flog: IFlog, entry: IEntry) => {
+        if (!flog || !Array.isArray(flog.loadedEntries)) {
+            console.error(`Flog or flog.loadedEntries is undefined or not an array: ${flog}`);
+            return;
+        }
+        // Find the index of the entry to delete
+        const editEntryIndex = flog.loadedEntries.findIndex(flogEntry => flogEntry.id === entry.id);
+        if (editEntryIndex !== -1) {
+            // Update the entry at the found index
+            flog.loadedEntries[editEntryIndex] = { ...flog.loadedEntries[editEntryIndex], ...entry };
+            // Save the updated flog to the source to persist the changes
+            saveFlogToSource(flog);
+        } else {
+            console.error('Entry not found in flog.loadedEntries');
+        }
     }
 
     const deleteEntryFromFlog = (flog: IFlog, entry: IEntry) => {
@@ -74,50 +258,104 @@ export const useFlogs = () => {
         }
     };
 
-    const editEntryFromFlog = (flog: IFlog, entry: IEntry) => {
-        if (!flog || !Array.isArray(flog.loadedEntries)) {
-            console.error(`Flog or flog.loadedEntries is undefined or not an array: ${flog}`);
-            return;
-        }
-        // Find the index of the entry to delete
-        const editEntryIndex = flog.loadedEntries.findIndex(flogEntry => flogEntry.id === entry.id);
-        if (editEntryIndex !== -1) {
-            // Update the entry at the found index
-            flog.loadedEntries[editEntryIndex] = { ...flog.loadedEntries[editEntryIndex], ...entry };
-            // Save the updated flog to the source to persist the changes
-            saveFlogToSource(flog);
-        } else {
-            console.error('Entry not found in flog.loadedEntries');
-        }
-    }
+    const accountOwner = ref<Map<IFlogSourceType, string | null>>(
+        new Map<IFlogSourceType, string | null>([
+            [IFlogSourceType.dropbox, null],
+            [IFlogSourceType.localFile, null],
+        ])
+    );
+    watch(accountOwner_dropbox,
+        () => {
+            console.log('watch accountOwner_dropbox', accountOwner_dropbox)
+            accountOwner.value.set(IFlogSourceType.dropbox, accountOwner_dropbox.value)
+            // accountOwner.value.set(IFlogSourceType.localFile, TBD)
+        },
+        { immediate: true }
+    )
 
-    const saveFlogToSource = (flog: IFlog) => {
-        switch (flog.sourceType) {
+    const launchConnectFlow = (sourceType: IFlogSourceType) => {
+        switch (sourceType) {
             case IFlogSourceType.dropbox:
-                saveFlogEntries_dropbox(flog as IDropboxFlog)
+                launchConnectFlow_dropbox();
                 break;
             default:
         }
     }
 
-    const addFlogToSource = (flog: IFlog) => {
-        switch (flog.sourceType) {
+    const openPopup = (sourceType: IFlogSourceType) => {
+        switch (sourceType) {
             case IFlogSourceType.dropbox:
-                addFlog_dropbox(flog as IDropboxFlog)
+                openDbxPopup_dropbox();
                 break;
             default:
         }
     }
+
+    const clearConnection = (sourceType: IFlogSourceType) => {
+        switch (sourceType) {
+            case IFlogSourceType.dropbox:
+                clearConnection_dropbox();
+                break;
+            default:
+        }
+    }
+
+    const hasConnection = ref<Map<IFlogSourceType, boolean>>(
+        new Map<IFlogSourceType, boolean>([
+            [IFlogSourceType.dropbox, false],
+            [IFlogSourceType.localFile, false],
+        ])
+    );
+    watch(hasConnection_dropbox,
+        () => {
+            console.log('watch hasConnection_dropbox', hasConnection_dropbox)
+            hasConnection.value.set(IFlogSourceType.dropbox, hasConnection_dropbox.value)
+            // hasConnection.value.set(IFlogSourceType.localFile, TBD)
+        },
+        { immediate: true }
+    )
+
+    const connectionPopupWindow = ref<Map<IFlogSourceType, any>>(
+        new Map<IFlogSourceType, any>([
+            [IFlogSourceType.dropbox, undefined],
+            [IFlogSourceType.localFile, undefined],
+        ])
+    );
+    watch(connectionPopupWindow_dropbox,
+        () => {
+            console.log('watch connectionPopupWindow_dropbox', connectionPopupWindow_dropbox)
+            connectionPopupWindow.value.set(IFlogSourceType.dropbox, connectionPopupWindow_dropbox.value)
+            // hasConnection.value.set(IFlogSourceType.localFile, TBD)
+        },
+        { immediate: true }
+    )
+
 
     return {
+        availableFlogs,
+        availableRepoFlogs,
+
+        addFlogToSource,
+        deleteFlogFromSource,
+
         openFlogs,
+
         openFlog,
+        loadFlogEntriesFromSource,
+        saveFlogToSource,
         closeFlog,
+
         addEntryToFlog,
         updatePretext,
-        saveFlogToSource,
-        deleteEntryFromFlog,
         editEntryFromFlog,
-        addFlogToSource
+        deleteEntryFromFlog,
+
+        accountOwner,
+
+        launchConnectFlow,
+        openPopup,
+        clearConnection,
+        connectionPopupWindow,
+        hasConnection,
     }
 }

--- a/src/composables/useOpenFlogs.ts
+++ b/src/composables/useOpenFlogs.ts
@@ -1,5 +1,6 @@
 import { ref, Ref, watch } from "vue"
 import type { IFlog } from "@/modules/Flog"
+import { IFlogSourceType } from "@/modules/Flog"
 import { useDropboxFlogs, IDropboxFlog } from "@/composables/useDropboxFlogs";
 
 
@@ -55,7 +56,7 @@ export const useOpenFlogs = () => {
 
     const saveFlogToSource = (flog: IFlog) => {
         switch (flog.sourceType) {
-            case 'dropbox':
+            case IFlogSourceType.dropbox:
                 saveFlogEntries_dropbox(flog as IDropboxFlog)
                 break;
             default:
@@ -64,7 +65,7 @@ export const useOpenFlogs = () => {
 
     const addFlogToSource = (flog: IFlog) => {
         switch (flog.sourceType) {
-            case 'dropbox':
+            case IFlogSourceType.dropbox:
                 addFlog_dropbox(flog as IDropboxFlog)
                 break;
             default:

--- a/src/composables/useOpenFlogs.ts
+++ b/src/composables/useOpenFlogs.ts
@@ -42,6 +42,8 @@ const {
 // See https://vuejs.org/guide/scaling-up/state-management#simple-state-management-with-reactivity-api
 const openFlogs = ref<IFlog[]>([])
 
+// Ref variables that are passed through from a specific use[Source]Flogs composable
+// need watchers on source variables
 watch(availableFlogs, () => {
     // if availableFlogs changes, filter out any openFlogs 
     // that are no longer in availableFlogs

--- a/src/composables/useOpenFlogs.ts
+++ b/src/composables/useOpenFlogs.ts
@@ -8,11 +8,24 @@ import { useDropboxFlogs, IDropboxFlog } from "@/composables/useDropboxFlogs";
 export type { IFlog as IFlog }
 
 interface IUseFlogs {
+    // ***************
+    // OPEN FLOGS
+    // ***************
+
+    // useOpenFlogs provides and manages one array for all open flogs 
+    // from all sources.
     openFlogs: Ref<IFlog[]>;
-    openFlog: (newFlog: IFlog) => void;
+
+    // useOpenFlogs provides the following flog operations
+    //      add, delete
+    // These map the operation to correct operation 
+    // for the flog's source
+    // 
+    // The following are functions that take a flog
+    // and call the appropriate pass through function
+    // from use[flog.sourceType]Flogs
+    openFlog: (flog: IFlog) => void;
     closeFlog: (flog: IFlog) => void;
-    saveFlogToSource: (flog: IFlog) => void;
-    addFlogToSource: (flog: IFlog) => void;
 }
 
 const {
@@ -54,29 +67,9 @@ export const useOpenFlogs = () => {
         }
     }
 
-    const saveFlogToSource = (flog: IFlog) => {
-        switch (flog.sourceType) {
-            case IFlogSourceType.dropbox:
-                saveFlogEntries_dropbox(flog as IDropboxFlog)
-                break;
-            default:
-        }
-    }
-
-    const addFlogToSource = (flog: IFlog) => {
-        switch (flog.sourceType) {
-            case IFlogSourceType.dropbox:
-                addFlog_dropbox(flog as IDropboxFlog)
-                break;
-            default:
-        }
-    }
-
     return {
         openFlogs,
         openFlog,
         closeFlog,
-        saveFlogToSource,
-        addFlogToSource
     }
 }

--- a/src/composables/useOpenFlogs.ts
+++ b/src/composables/useOpenFlogs.ts
@@ -1,6 +1,6 @@
 import { ref, Ref, watch } from "vue"
 import type { IFlog } from "@/composables/useFlogSource"
-import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource.ts";
+import { useFlogSource, IFlogSourceType } from "@/composables/useFlogSource";
 
 
 // Re-export these for convenience

--- a/src/modules/Flog.ts
+++ b/src/modules/Flog.ts
@@ -3,7 +3,7 @@ import type { IEntry } from './EntryData'
 export enum IFlogStatus { loaded, error };
 
 
-export enum IFlogSourceType { "dropbox", "local file" };
+export enum IFlogSourceType { "dropbox", "localFile" };
 
 interface IFlogCore {
     loadedEntries: IEntry[],

--- a/src/modules/Flog.ts
+++ b/src/modules/Flog.ts
@@ -2,13 +2,16 @@ import type { IEntry } from './EntryData'
 
 export enum IFlogStatus { loaded, error };
 
+
+export enum IFlogSourceType { "dropbox", "local file" };
+
 interface IFlogCore {
     loadedEntries: IEntry[],
     pretext?: string,
     status?: IFlogStatus
 }
 export interface IFlog extends IFlogCore {
-    sourceType: "dropbox" | "local file",
+    sourceType: IFlogSourceType,
     url: string,
     permissions?: string,
     readOnly?: boolean,


### PR DESCRIPTION
Note:
The useOpenFlogs methods are still duplicated inside useFlogs. Further refactor is necessary.

For radical simplicity, we could reverse what this PR does — have components use useDropboxFlogs directly and get rid of useFlogs and the layer of abstraction for multiple sources.

Either way I think we merge in this iteration refactor and move forward from there. There's new good documentation in the file that could be ported to useDropboxFlogs.